### PR TITLE
unsolved block's height is improperly updated by chain tip height

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3888,9 +3888,13 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
     {
         CScript expect = CScript() << nHeight;
         if (block.vtx[0].vin[0].scriptSig.size() < expect.size() ||
-            !std::equal(expect.begin(), expect.end(), block.vtx[0].vin[0].scriptSig.begin())) {
-            return state.DoS(100, error("%s: block height mismatch in coinbase", __func__), REJECT_INVALID, "bad-cb-height");
-        }
+            !std::equal(expect.begin(), expect.end(), block.vtx[0].vin[0].scriptSig.begin()))
+          {
+            int blockCoinbaseHeight = block.GetHeight();
+            uint256 hashp = block.hashPrevBlock;
+            uint256 hash = block.GetHash();
+            return state.DoS(100, error("%s: block height mismatch in coinbase, expected %d, got %d, block is %s, parent block is %s, pprev is %s", __func__,nHeight,blockCoinbaseHeight,hash.ToString(),hashp.ToString(), pindexPrev->phashBlock->ToString()), REJECT_INVALID, "bad-cb-height");
+          }
     }
 
     return true;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -179,7 +179,10 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
         LOCK2(cs_main, mempool.cs);
         CBlockIndex* pindexPrev = chainActive.Tip();
         const int nHeight = pindexPrev->nHeight + 1;
-        pblock->nTime = GetAdjustedTime();
+        // Fill in header
+        pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
+        pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());        
+        pblock->nTime          = GetAdjustedTime();
         const int64_t nMedianTimePast = pindexPrev->GetMedianTimePast();
 
         pblock->nVersion = UnlimitedComputeBlockVersion(pindexPrev, chainparams.GetConsensus(),pblock->nTime);
@@ -361,11 +364,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
         
         pblock->vtx[0] = txNew;
         pblocktemplate->vTxFees[0] = -nFees;
-
-        // Fill in header
-        pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
         UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev);
-        pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());
         pblock->nNonce         = 0;
         pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(pblock->vtx[0]);
 
@@ -392,7 +391,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
     return pblocktemplate.release();
 }
 
-void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce)
+void IncrementExtraNonce(CBlock* pblock, unsigned int& nExtraNonce)
 {
     // Update nExtraNonce
     static uint256 hashPrevBlock;
@@ -402,7 +401,7 @@ void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned
         hashPrevBlock = pblock->hashPrevBlock;
     }
     ++nExtraNonce;
-    unsigned int nHeight = pindexPrev->nHeight+1; // Height first in coinbase required for block.version=2
+    unsigned int nHeight = pblock->GetHeight(); // Height first in coinbase required for block.version=2
     CMutableTransaction txCoinbase(pblock->vtx[0]);
  
     CScript script = (CScript() << nHeight << CScriptNum(nExtraNonce));

--- a/src/miner.h
+++ b/src/miner.h
@@ -30,7 +30,7 @@ struct CBlockTemplate
 /** Generate a new block, without valid proof-of-work */
 CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn);
 /** Modify the extranonce in a block */
-void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
+void IncrementExtraNonce(CBlock* pblock, unsigned int& nExtraNonce);
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
 #endif // BITCOIN_MINER_H

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -122,6 +122,18 @@ public:
         READWRITE(vtx);
     }
 
+    uint64_t GetHeight() const  // Returns the block's height as specified in its coinbase transaction
+    {
+      const CScript& sig = vtx[0].vin[0].scriptSig;
+      int numlen = sig[0];
+      if (numlen == OP_0) return 0;
+      if ((numlen >= OP_1) && (numlen <= OP_16)) return numlen-OP_1+1;
+      std::vector<unsigned char> heightScript(numlen);
+      copy(sig.begin()+1, sig.begin()+1+numlen,heightScript.begin());
+      CScriptNum coinbaseHeight(heightScript, false,numlen);
+      return coinbaseHeight.getint();
+    }
+    
     void SetNull()
     {
         CBlockHeader::SetNull();

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -119,8 +119,8 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript, int nG
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;
         {
-            LOCK(cs_main);
-            IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
+          // LOCK(cs_main);
+            IncrementExtraNonce(pblock, nExtraNonce);
         }
         while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus())) {
             ++pblock->nNonce;
@@ -525,9 +525,9 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     }
 
     // Update block
-    static CBlockIndex* pindexPrev;
-    static int64_t nStart;
-    static CBlockTemplate* pblocktemplate;
+    static CBlockIndex* pindexPrev = NULL;
+    static int64_t nStart = 0;
+    static CBlockTemplate* pblocktemplate = NULL;
     if (pindexPrev != chainActive.Tip() ||
         (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 5))
     {
@@ -674,7 +674,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.push_back(Pair("sizelimit", (int64_t)maxGeneratedBlock));
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
     result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
-    result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));
+    result.push_back(Pair("height", (int64_t)(pblock->GetHeight()))); // BU get the height directly from the block because pindexPrev could change if another block has come in.
 
     return result;
 }

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -109,7 +109,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
         block.vtx.push_back(tx);
     // IncrementExtraNonce creates a valid coinbase and merkleRoot
     unsigned int extraNonce = 0;
-    IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
+    IncrementExtraNonce(&block, extraNonce);
 
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -807,7 +807,7 @@ void static BitcoinMiner(const CChainParams& chainparams)
                 return;
             }
             CBlock *pblock = &pblocktemplate->block;
-            IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
+            IncrementExtraNonce(pblock, nExtraNonce);
 
             LogPrintf("Running BitcoinMiner with %u transactions in block (%u bytes)\n", pblock->vtx.size(),
                 ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION));


### PR DESCRIPTION
fix bug where an unsolved block's height is improperly updated based on the chain tip.  But the chain tip might have advanced from the time the block was created and the time the height was updated.