### PR TITLE
cast nTime to int64_t

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -296,7 +296,7 @@ static arith_uint256 ComputeTarget(const CBlockIndex *pindexFirst,
 
     // In order to avoid difficulty cliffs, we bound the amplitude of the
     // adjustement we are going to do.
-    int64_t nActualTimespan = pindexLast->nTime - pindexFirst->nTime;
+    int64_t nActualTimespan = int64_t(pindexLast->nTime) - int64_t(pindexFirst->nTime);
     if (nActualTimespan > 288 * params.nPowTargetSpacing)
     {
         nActualTimespan = 288 * params.nPowTargetSpacing;


### PR DESCRIPTION
to avoid an unsigned result then it will be sign extended